### PR TITLE
fix: ProfileViewのいいね数と投稿数が正しい値を表示するよう修正

### DIFF
--- a/PositiveWordsCollection/Model/PostArrayObject.swift
+++ b/PositiveWordsCollection/Model/PostArrayObject.swift
@@ -12,11 +12,13 @@ class PostArrayObject: ObservableObject {
     @Published var dataArray: [PostModel] = []
     @Published var userPostArray: [PostModel] = []
     @Published var myUserPostArray: [PostModel] = []
-
+    
     // ProfileViewが一度も表示されていない時ポスト追加
     @Published var profileViewOn = false
-    @Published var postCountString = "0"
-    @Published var likeCountString = "0"
+    @Published var myPostCountString = ""
+    @Published var myLikeCountString = ""
+    @Published var userPostCountString = ""
+    @Published var userLikeCountString = ""
     private var lastDocument: DocumentSnapshot? = nil
     private var lastUserDocument: DocumentSnapshot? = nil
     private var lastMyUserDocument: DocumentSnapshot? = nil
@@ -35,6 +37,7 @@ class PostArrayObject: ObservableObject {
             print("\(error)")
         }
     }
+    
     func refreshUpdateMyUserPost(userID: String) async {
         myUserPostArray = []
         lastMyUserDocument = nil
@@ -56,17 +59,13 @@ class PostArrayObject: ObservableObject {
         var isMyLastPost = false
         do {
             let (newPosts, lastMyUserDocument) = try await DataService.instance.getUserFeed(userId: userID, lastDocument: lastMyUserDocument)
-            print("🟥\(newPosts)")
             // 最新の日付
             let sortedPosts = newPosts.sorted { (post1, post2) -> Bool in
                 return post1.dateCreated > post2.dateCreated
             }
-            print("🟩\(myUserPostArray)")
             self.myUserPostArray.append(contentsOf: sortedPosts)
-            print("🐥\(myUserPostArray)")
             if let lastMyUserDocument {
                 self.lastMyUserDocument = lastMyUserDocument
-                //                    self.updateCounts(userID: userID)
             } else {
                 // nilならば
                 isMyLastPost = true
@@ -76,29 +75,24 @@ class PostArrayObject: ObservableObject {
         }
         return isMyLastPost
     }
-
-    func reset() {
-
+    
+    func resetPostArray() {
         userPostArray = []
         lastUserDocument = nil
     }
-
+    
     func refreshUserPost(userID: String) async -> (Bool) {
         profileViewOn = true
         var isLastPost = false
         do {
             let (newPosts, lastUserDocument) = try await DataService.instance.getUserFeed(userId: userID, lastDocument: lastUserDocument)
-            print("🟥\(newPosts)")
             // 最新の日付
             let sortedPosts = newPosts.sorted { (post1, post2) -> Bool in
                 return post1.dateCreated > post2.dateCreated
             }
-            print("🟩\(userPostArray)")
             self.userPostArray.append(contentsOf: sortedPosts)
-            print("🐥\(userPostArray)")
             if let lastUserDocument {
                 self.lastUserDocument = lastUserDocument
-                //                    self.updateCounts(userID: userID)
             } else {
                 // nilならば
                 isLastPost = true
@@ -126,22 +120,40 @@ class PostArrayObject: ObservableObject {
         return isLastPost
     }
     
+    
     // like
-    func updateCounts(userID: String) {
-        postCountString = "0"
-        likeCountString = "0"
+    func updateUserCounts(userID: String) {
+        userPostCountString = ""
+        userLikeCountString = ""
         Task {
             do {
                 let sum = try await DataService.instance.sumLikePost(userID: userID)
-                likeCountString = "\(sum)"
-                print("🩵いいね数\(sum)")
+                userLikeCountString = "\(sum)"
             } catch {
-                print("🩵SumLike Error")
                 print(error)
             }
             do {
                 let postCount = try await DataService.instance.sumUserPost(userID: userID)
-                postCountString = String(postCount)
+                userPostCountString = String(postCount)
+            } catch {
+                print("PostCount Error")
+            }
+        }
+    }
+    
+    func updateMyCounts(userID: String) {
+        myPostCountString = ""
+        myLikeCountString = ""
+        Task {
+            do {
+                let sum = try await DataService.instance.sumLikePost(userID: userID)
+                myLikeCountString = "\(sum)"
+            } catch {
+                print(error)
+            }
+            do {
+                let postCount = try await DataService.instance.sumUserPost(userID: userID)
+                myPostCountString = String(postCount)
             } catch {
                 print("PostCount Error")
             }

--- a/PositiveWordsCollection/View/Profile/ProfileHeaderView.swift
+++ b/PositiveWordsCollection/View/Profile/ProfileHeaderView.swift
@@ -46,9 +46,15 @@ struct ProfileHeaderView: View {
                 VStack(alignment: .center, spacing: 5, content: {
                     HStack {
                         Image(systemName: "paperplane")
-                        Text(posts.postCountString)
-                            .font(.title2)
-                            .fontWeight(.bold)
+                        if isMyProfile == true {
+                            Text(posts.myPostCountString)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                        } else {
+                            Text(posts.userPostCountString)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                        }
                     }
 
                     Capsule()
@@ -64,9 +70,15 @@ struct ProfileHeaderView: View {
                     HStack {
                         Image(systemName: "heart.fill")
                             .foregroundStyle(.red)
-                        Text(posts.likeCountString)
-                            .font(.title2)
-                            .fontWeight(.bold)
+                        if isMyProfile == true {
+                            Text(posts.myLikeCountString)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                        } else {
+                            Text(posts.userLikeCountString)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                        }
                     }
                     Capsule()
                         .fill(.red)

--- a/PositiveWordsCollection/View/Profile/ProfileView.swift
+++ b/PositiveWordsCollection/View/Profile/ProfileView.swift
@@ -21,7 +21,7 @@ struct ProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     @State var firstAppear = true
     @State var showBlockAlert = false
-
+    
     var body: some View {
         ProfileHeaderView(profileUserID: profileUserID, profileDisplayName: $profileDisplayName, profileImage: $profileImage, profileBio: profileBio, isMyProfile: isMyProfile, posts: posts)
             .padding(.top, 10)
@@ -33,7 +33,7 @@ struct ProfileView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(Color.colorBeige, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
-
+        
             .toolbar {
                 if isMyProfile {
                     Button(action: {
@@ -63,7 +63,7 @@ struct ProfileView: View {
             }
             .alert("このユーザーをブロックしますか？", isPresented: $showBlockAlert, actions: {
                 Button("戻る", role: .cancel) {
-
+                    
                 }
                 Button("ブロックする", role: .destructive) {
                     // 🟥ブロックする
@@ -99,7 +99,7 @@ struct ProfileView: View {
     
     // MARK: FUNCTION
     // Block
-
+    
     private func blockUser(profileUserID: String) {
         guard let myUserID = currentUserID else { return }
         Task {
@@ -111,17 +111,17 @@ struct ProfileView: View {
             }
         }
     }
-
+    
     func profileUpdate(userID: String) {
         Task {
             if isMyProfile {
+                posts.updateMyCounts(userID: userID)
                 _ = await posts.refreshMyUserPost(userID: userID)
-                posts.updateCounts(userID: userID)
             } else {
                 Task {
-                    posts.reset()
+                    posts.resetPostArray()
+                    posts.updateUserCounts(userID: userID)
                     _ = await posts.refreshUserPost(userID: userID)
-                    posts.updateCounts(userID: userID)
                 }
             }
         }


### PR DESCRIPTION
別のユーザーのいいね数とポスト数が自分のProfileのタブに切り替えたとき保持されるエラーを修正