### PR TITLE
update SimultaneousGesture

### DIFF
--- a/PositiveWordsCollection/View/Profile/EditProfileView.swift
+++ b/PositiveWordsCollection/View/Profile/EditProfileView.swift
@@ -131,9 +131,12 @@ struct EditProfileView: View {
         .alert(isPresented: $showEditProfileError) {
             Alert(title: Text("名前は空にできません。"))
         }
-        .onTapGesture {
-            focusedField = nil
-        }
+        .simultaneousGesture(
+            TapGesture()
+                .onEnded {
+                    focusedField = nil
+                }
+        )
         .onAppear {
             guard let userName = currentUserName else { return }
             guard let userBio = currentBio else { return }

--- a/PositiveWordsCollection/View/SignInProfileView.swift
+++ b/PositiveWordsCollection/View/SignInProfileView.swift
@@ -30,16 +30,18 @@ struct SignInProfileView: View {
                         Text("プロフィール画像")
                             .font(.title2)
                             .fontWeight(.bold)
-                        Image(uiImage: viewModel.selectedImage ?? UIImage(named: "noImage")!)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 200, height: 200)
-                            .clipShape(RoundedRectangle(cornerRadius: 150))
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 150)
-                                    .stroke(Color.black, lineWidth: 3.0)
-                            }
-                            .contentShape(Rectangle())
+                        PhotosPicker(selection: $selectedItem) {
+                            Image(uiImage: viewModel.selectedImage ?? UIImage(named: "noImage")!)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 200, height: 200)
+                                .clipShape(RoundedRectangle(cornerRadius: 150))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 150)
+                                        .stroke(Color.black, lineWidth: 3.0)
+                                }
+                                .contentShape(Rectangle())
+                        }
                         PhotosPicker(selection: $selectedItem) {
                             Text("ライブラリから画像を選択")
                                 .font(.headline)
@@ -111,13 +113,12 @@ struct SignInProfileView: View {
                     }
                 }
             }
-            if focusedField != nil {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture {
+            .simultaneousGesture(
+                TapGesture()
+                    .onEnded {
                         focusedField = nil
                     }
-            }
+            )
             if isLoading {
                 ProgressView()
                     .progressViewStyle(.circular)


### PR DESCRIPTION
[SimultaneousGesture](https://developer.apple.com/documentation/swiftui/simultaneousgesture)
二つのジェスチャーが同時に発生することを許容する実装に変更
```
if focusedField != nil {
                Color.clear
                    .contentShape(Rectangle())
                    .onTapGesture {
                        focusedField = nil
                    }
            }
```
①TextFieldにフォーカスが当たっている状態から「ライブラリから画像を選択」ボタンを押す！
②ライブラリは開かず、キーボードを閉じる(タップが競合できない状態にあったの)
③キーボードを閉じた状態で「ライブラリから画像を選択」ボタンを押すとライブラリが開く。
という挙動になってしまっていました。

```
  .simultaneousGesture(
      TapGesture().onEnded {
        focusedField = nil
      }
    )
```
①TextFieldにフォーカスが当たっている状態から「ライブラリから画像を選択」ボタンを押す！
②タップが競合できるので、ライブラリが開き、キーボードも閉じる(理想的な挙動:angel-nya:)